### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/lib/lolcommits/plugin/tranzlate.rb
+++ b/lib/lolcommits/plugin/tranzlate.rb
@@ -6,15 +6,6 @@ module Lolcommits
     class Tranzlate < Base
       extend Lolcommits::Tranzlate::Lolspeak
 
-      ##
-      # Returns the name of the plugin. Identifies the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'tranzlate'
-      end
-
       # Returns position(s) of when this plugin should run during the capture
       # process.
       #

--- a/lib/lolcommits/tranzlate/version.rb
+++ b/lib/lolcommits/tranzlate/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Tranzlate
-    VERSION = "0.0.5".freeze
+    VERSION = "0.0.6".freeze
   end
 end

--- a/lolcommits-tranzlate.gemspec
+++ b/lolcommits-tranzlate.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/test/lolcommits/plugin/tranzlate_test.rb
+++ b/test/lolcommits/plugin/tranzlate_test.rb
@@ -5,48 +5,26 @@ describe Lolcommits::Plugin::Tranzlate do
   include Lolcommits::TestHelpers::GitRepo
   include Lolcommits::TestHelpers::FakeIO
 
-  it 'should have a name' do
-    ::Lolcommits::Plugin::Tranzlate.name.must_equal 'tranzlate'
-  end
-
   it 'should run on post capturing' do
     ::Lolcommits::Plugin::Tranzlate.runner_order.must_equal [:pre_capture]
   end
 
   describe 'with a runner' do
     def runner
-      # a simple lolcommits runner with an empty configuration Hash
-      @runner ||= Lolcommits::Runner.new(
-        config: OpenStruct.new(read_configuration: {})
-      )
+      @runner ||= Lolcommits::Runner.new
     end
 
     def plugin
       @plugin ||= Lolcommits::Plugin::Tranzlate.new(runner: runner)
     end
 
-    def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: {
-          plugin.class.name => { 'enabled' => true }
-        }
-      )
-    end
-
-    describe 'initalizing' do
-      it 'should assign runner and an enabled option' do
-        plugin.runner.must_equal runner
-        plugin.options.must_equal ['enabled']
-      end
-    end
-
     describe '#enabled?' do
       it 'should be false by default' do
-        plugin.enabled?.must_equal false
+        assert_nil plugin.enabled?
       end
 
       it 'should true when configured' do
-        plugin.config = valid_enabled_config
+        plugin.configuration = { enabled: true }
         plugin.enabled?.must_equal true
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* bump gem version (for new plugin release)